### PR TITLE
[FIX] use the column._symbol-c as placeholder for the column value

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -4156,7 +4156,7 @@ class BaseModel(object):
         for field in vals:
             current_field = self._columns[field]
             if current_field._classic_write:
-                updates.append((field, '%s', current_field._symbol_set[1](vals[field])))
+                updates.append((field, current_field._symbol_set[0], current_field._symbol_set[1](vals[field])))
 
                 #for the function fields that receive a value, we set them directly in the database
                 #(they may be required), but we also need to trigger the _fct_inv()


### PR DESCRIPTION
When generating the SQL query in  the low level '_create' method from
BaseModel, column._synbol-c must be used as placeholder as for the
method 'set' of the column itself. Otherwise it's no more possible to define specialized column.
